### PR TITLE
Fix JBIDE-12955 bad relative path after git move

### DIFF
--- a/tycho-plugins/repository-utils/pom.xml
+++ b/tycho-plugins/repository-utils/pom.xml
@@ -10,7 +10,6 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>tycho-plugins</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<dependencies>

--- a/tycho-plugins/target-platform-utils/pom.xml
+++ b/tycho-plugins/target-platform-utils/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.jboss.tools</groupId>
     <artifactId>tycho-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <groupId>org.jboss.tools.tycho-plugins</groupId>
   <artifactId>target-platform-utils</artifactId>


### PR DESCRIPTION
In maven-plugins I found relativePath was set to ..

Since that is the default for relativePath any reason to specify it ?
