### PR TITLE
Trivial fix - use released version of download-maven-plugin

### DIFF
--- a/tycho-plugins/repository-utils/pom.xml
+++ b/tycho-plugins/repository-utils/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.googlecode.maven-download-plugin</groupId>
 			<artifactId>download-maven-plugin</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.2.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The SNAPSHOT version is no longer available and a build on a clean local
repo fails.
