### PR TITLE
JBIDE-22162: Support Tycho 0.25.0

### DIFF
--- a/tycho-plugins/discovery-utils/pom.xml
+++ b/tycho-plugins/discovery-utils/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>tycho-plugins</artifactId>
-		<version>0.23.4-SNAPSHOT</version>
+		<version>0.25.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/tycho-plugins/pom.xml
+++ b/tycho-plugins/pom.xml
@@ -16,9 +16,9 @@
 	<artifactId>tycho-plugins</artifactId>
 	<packaging>pom</packaging>
 	<name>jbosstools-tycho-plugins-parent</name>
-	<version>0.23.4-SNAPSHOT</version>
+	<version>0.25.0-SNAPSHOT</version>
 	<properties>
-		<tychoVersion>0.23.1</tychoVersion>
+		<tychoVersion>0.25.0</tychoVersion>
 	</properties>
 
 	<description>In-House Maven plugins for JBT/JBDS build</description>

--- a/tycho-plugins/repository-utils/pom.xml
+++ b/tycho-plugins/repository-utils/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>tycho-plugins</artifactId>
-		<version>0.23.4-SNAPSHOT</version>
+		<version>0.25.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/tycho-plugins/target-platform-utils/pom.xml
+++ b/tycho-plugins/target-platform-utils/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>tycho-plugins</artifactId>
-    <version>0.23.4-SNAPSHOT</version>
+    <version>0.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.tycho-plugins</groupId>
   <artifactId>target-platform-utils</artifactId>

--- a/tycho-plugins/target-platform-utils/src/main/java/org/jboss/tools/tycho/targets/TargetToRepoMojo.java
+++ b/tycho-plugins/target-platform-utils/src/main/java/org/jboss/tools/tycho/targets/TargetToRepoMojo.java
@@ -126,7 +126,8 @@ public class TargetToRepoMojo extends AbstractMojo {
 	        	}
 	        }
 
-	        final DestinationRepositoryDescriptor destinationDescriptor = new DestinationRepositoryDescriptor(this.outputRepository, this.sourceTargetFile.getName(), true, false, true);
+			final DestinationRepositoryDescriptor destinationDescriptor = new DestinationRepositoryDescriptor(this.outputRepository, this.sourceTargetFile.getName(), true, true,
+					false, false, true);
 
 	        List<IUDescription> initialIUs = new ArrayList<IUDescription>();
 	        for (final Location loc : target.getLocations()) {

--- a/tycho-plugins/tycho-dependency-plugin/pom.xml
+++ b/tycho-plugins/tycho-dependency-plugin/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>tycho-plugins</artifactId>
-    <version>0.23.4-SNAPSHOT</version>
+    <version>0.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.tycho-plugins</groupId>
   <artifactId>tycho-dependency-plugin</artifactId>


### PR DESCRIPTION
- update one constructor to support xz compress
- aligned JBoss Tycho Maven plugins version numbers to the Tycho version

I tested then on JBoss Tooling. The TP has built and I was able to use it.