### PR TITLE
fix findRepoRoot throwing NPE if git repository is not found

### DIFF
--- a/tycho-plugins/repository-utils/src/main/java/org/jboss/tools/tycho/sitegenerator/GenerateRepositoryFacadeMojo.java
+++ b/tycho-plugins/repository-utils/src/main/java/org/jboss/tools/tycho/sitegenerator/GenerateRepositoryFacadeMojo.java
@@ -907,7 +907,7 @@ public class GenerateRepositoryFacadeMojo extends AbstractTychoPackagingMojo {
 	}
 
 	protected static File findRepoRoot(File repoRoot) throws FileNotFoundException {
-		while (! new File(repoRoot, ".git").isDirectory()) {
+		while (repoRoot != null && ! new File(repoRoot, ".git").isDirectory()) {
 			repoRoot = repoRoot.getParentFile();
 		}
 		if (repoRoot == null) {


### PR DESCRIPTION
findRepoRoot() throws a NullPointerException if run outside of a git repository:

`[ERROR] Failed to execute goal org.jboss.tools.tycho-plugins:repository-utils:0.26.0:generate-repository-facade (generate-facade) on project com.rtlabs.ecat.p2update: Could not add revision to buildinfo.json: NullPointerException -> [Help 1]
`

`Caused by: java.lang.NullPointerException
        at org.jboss.tools.tycho.sitegenerator.GenerateRepositoryFacadeMojo.findRepoRoot(GenerateRepositoryFacadeMojo.java:911)
        at org.jboss.tools.tycho.sitegenerator.GenerateRepositoryFacadeMojo.createRevisionObject(GenerateRepositoryFacadeMojo.java:880)
        at org.jboss.tools.tycho.sitegenerator.GenerateRepositoryFacadeMojo.createBuildInfo(GenerateRepositoryFacadeMojo.java:733)
`