### PR TITLE
Skip altering 'content.jar' if it doesn't exist, skip deleting the original repo references if 'associatedSites' is not defined

### DIFF
--- a/tycho-plugins/repository-utils/src/main/java/org/jboss/tools/tycho/sitegenerator/GenerateRepositoryFacadeMojo.java
+++ b/tycho-plugins/repository-utils/src/main/java/org/jboss/tools/tycho/sitegenerator/GenerateRepositoryFacadeMojo.java
@@ -280,7 +280,9 @@ public class GenerateRepositoryFacadeMojo extends AbstractTychoPackagingMojo {
             generateWebStuff(outputRepository, outputCategoryXml);
 		}
 		try {
-			alterContentJar(outputRepository);
+			if (new File(p2repository, "content.jar").exists()) {
+				alterContentJar(outputRepository);
+			}
 		} catch (Exception ex) {
 			throw new MojoExecutionException("Error while altering content.jar", ex);
 		}
@@ -487,7 +489,7 @@ public class GenerateRepositoryFacadeMojo extends AbstractTychoPackagingMojo {
 			if (entry.getName().equals("content.xml")) {
 				contentDoc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(contentStream);
 				Element repoElement = (Element) contentDoc.getElementsByTagName("repository").item(0);
-				{
+				if (this.associateSites != null) {
 					NodeList references = repoElement.getElementsByTagName("references");
 					// remove default references
 					for (int i = 0; i < references.getLength(); i++) {
@@ -495,7 +497,7 @@ public class GenerateRepositoryFacadeMojo extends AbstractTychoPackagingMojo {
 						currentRef.getParentNode().removeChild(currentRef);
 					}
 					// add associateSites
-					if (this.associateSites != null && this.associateSites.size() > 0 && this.referenceStrategy == ReferenceStrategy.embedReferences) {
+					if (this.associateSites.size() > 0 && this.referenceStrategy == ReferenceStrategy.embedReferences) {
 						Element refElement = contentDoc.createElement("references");
 						refElement.setAttribute("size", Integer.valueOf(2 * associateSites.size()).toString());
 						for (String associate : associateSites) {


### PR DESCRIPTION
Hey committers,

I suggest to let the `generate-facade` mojo touch the repository references within `content.xml` only, if an alternative list is given in the configuration section, esp. delete the pre-existing references only if at least an empty list is defined, like
```
    <configuration>
      <associateSites/>
      <siteTemplateFolder>siteTemplate</siteTemplateFolder>
      ...
    </configuration>

```
Background: With https://github.com/eclipse-tycho/tycho/pull/145 Tycho produces proper repositories references and it's not needed to touch them anymore, but I would love to be able to still use the web content generation.

In addition, I added a check to touch the `content.jar` only if it exists.
Background: I tried to bind `generate-facade` to an earlier phase like `compile`, and with the current impl the mojo just fails.